### PR TITLE
Add some examples based on STP

### DIFF
--- a/binary/examples/stp-collection-after8.cbord
+++ b/binary/examples/stp-collection-after8.cbord
@@ -1,0 +1,10 @@
+/ This is part of the stp-collection example /
+
+[
+  [2, 6(23 / container:item /), cri'./9'],
+  [2, 6(23 / container:item /), cri'./10'],
+  [2, 6(23 / container:item /), cri'./11'],
+  [2, 6(23 / container:item /), cri'./12'],
+  [2, 6(23 / container:item /), cri'./13'],
+  [2, 6(42 / stp:next /), cri'stp-collection-after8.cbord']
+]

--- a/binary/examples/stp-collection.cbord
+++ b/binary/examples/stp-collection.cbord
@@ -1,0 +1,16 @@
+/ What could STP (Series Transfer Pattern) look like in CoRAL?        /
+/                                                                     /
+/ This assumes a basic collection pattern, applied to a long list of  /
+/ very generic resources.                                             /
+
+[
+  [2, 6(23 / container:item /), cri'./1'],
+  [2, 6(23 / container:item /), cri'./2'],
+  [2, 6(23 / container:item /), cri'./3'],
+  [2, 6(23 / container:item /), cri'./4'],
+  [2, 6(23 / container:item /), cri'./5'],
+  [2, 6(23 / container:item /), cri'./6'],
+  [2, 6(23 / container:item /), cri'./7'],
+  [2, 6(23 / container:item /), cri'./8'],
+  [2, 6(42 / stp:next /), cri'stp-collection-after8.cbord']
+]

--- a/binary/examples/stp-index-0.cbord
+++ b/binary/examples/stp-index-0.cbord
@@ -1,0 +1,12 @@
+/ This is part of the stp-index example /
+
+[
+  / Actually, rather than just sending the embedded representation, could have sent the bare value just as well /
+  [2, 6(0 / coral:current-representation), 6.1668546672(
+    / 1668546560 + 112 for application/senml+cbor /
+    [
+      {-2 / bn /: "urn:dev:...", -4 / "bu" /: "Cel", -3 / "bt": 1234567890, 2 / "v" /: 39.1},
+      { / ... /}
+    ]
+  )]
+]

--- a/binary/examples/stp-index-1.cbord
+++ b/binary/examples/stp-index-1.cbord
@@ -1,0 +1,13 @@
+/ This is part of the stp-index example /
+
+[
+  / Not indicating this is growing any more /
+  [2, 6(42 / stp:next /), cri'stp-index-0.cbord'],
+  [2, 6(0 / coral:current-representation), 6.1668546672(
+    / 1668546560 + 112 for application/senml+cbor /
+    [
+      {-2 / bn /: "urn:dev:...", -4 / "bu" /: "Cel", -3 / "bt": 1234571490, 2 / "v" /: 39.1},
+      { / ... /}
+    ]
+  )]
+]

--- a/binary/examples/stp-index-2.cbord
+++ b/binary/examples/stp-index-2.cbord
@@ -1,0 +1,16 @@
+/ This is part of the stp-index example /
+
+[
+  / Yes I'm still growing (independenlty of whether you just observe /
+  / me or not) /
+  [2, 6(10 / core:obs /), true],
+  [2, 6(42 / stp:next /), cri'stp-index-1.cbord'],
+  / Alternatively to an embedded representation, multipart would just be another option /
+  [2, 6(0 / coral:current-representation), 6.1668546672(
+    / 1668546560 + 112 for application/senml+cbor /
+    [
+      {-2 / bn /: "urn:dev:...", -4 / "bu" /: "Cel", -3 / "bt": 1234575090, 2 / "v" /: 39.1},
+      { / ... /}
+    ]
+  )]
+]

--- a/binary/examples/stp-index.cbord
+++ b/binary/examples/stp-index.cbord
@@ -1,0 +1,23 @@
+/ What could STP (Series Transfer Pattern) look like in CoRAL?        /
+/                                                                     /
+/ This assumes a series that is not expressed natively in CoRAL but   /
+/ by representations in another format (SenML). It pagination from a  /
+/ head, packs representations in together with the CoRAL, and also    /
+/ explores a form for random access.                                  /
+
+[
+  [2, 6(42 / stp:next /), cri'stp-index-2.cbord', [
+    / Being still observable means it's still growing. /
+    [2, 6(10 / core:obs /), true]
+  ]],
+  [2, 6(55 / stp:search /), null, [
+    / Form that describes how /
+    [2, 6(81 / form:target /), cri'cgi-bin/stp-index-search.php'],
+    [2, 6(82 / form:method /), 6(825 / FETCH /)],
+    [2, 6(83 / form:builder /), 6(559 / form:build-a-senml-fetch-out-of-what-you-are-looking-for /)],
+  ]],
+  / I seriously doubt anyone wants CRI templates, so this is in URI template /
+  / form. High data rate parallel fetchers might still want to use that      /
+  / information.                                                             /
+  [2, 6(56 / stp:all-are-of-this-form /), "stp-index-{linear}.cbord"]]
+  ]


### PR DESCRIPTION
This is rough and could be done in many different ways, but it shows some terms needed from STP (given that HTML's rel:next is probably too fuzzy), and also describes a form (using the as-links representation that the binary format has a more efficient version of, but I don't know that well enough).

Note that a very schema-driven, non-HATEOS, hard-paginating spec could *prescibe* that some resource follow the `[2, 6(56 / stp:all-are-of-this-form /), "stp-index-{linear}.cbord"]]` template. Such clients would ignore the additional semantic information and go right for the file names, while the serves could still provide that (and the other) information to be accessible to non-schema-aware consumers.