### PR TITLE
No literal properties

### DIFF
--- a/draft-ietf-core-coral.md
+++ b/draft-ietf-core-coral.md
@@ -163,10 +163,7 @@ and the object is either a URI, a blank node or a litreal.
 All URIs here are limited to the syntax-based normalized form of {{RFC3986}} Section 6.2.2.
 
 Blank nodes are unnamed entities.
-Literals are non-null CBOR objects that may have a set of properties (e.g. a language tag) attached to them;
-properties have a (not necessarily unique) URI as their name
-and a URI or literal as their value.
-<!-- Do we need this? -->
+Literals are CBOR objects.
 
 These triples form a directed multigraph with the subject and object being source and destination, and the predicate a description <!-- not "label", because that implies uniqueness of the labels in Wikipedia definition --> on the edge.
 That graph is equivalent to the data.
@@ -175,9 +172,7 @@ To form a set and a graph, we define an equivalence relation:
 URIs are only equal to URIs and if they are identical byte-wise.
 A blank node is only equal to itself.
 A literal is equal to a different literal if
-its value is equal to another literal's value in the CBOR generic data model,
-and have the same set of properties.
-<!-- This is a recursive definition. -->
+its value is equal to the other literal's value in the CBOR generic data model.
 
 Triples are equivalent to each other if their subject, predicate and object are pair-wise equivalent.
 
@@ -226,12 +221,6 @@ However, statements can be added to make a data set that is expressible elsewher
 <!-- possibly shove around to make use of CURIEs introduced at some point -->
 (this document defines the `carries-information-about` relation type leading to the `http://www.iana.org/assignments/relation/carries-information-about` predicate being usable here),
 and subsets of the data can be taken and expressed.
-
-Literals with properties behave similar to blank nodes
-(where their properties resemble statements from a blank node) --
-so similar that they are serialized precisely like that.
-The difference is that properties are part of the literal's identity.
-The structured model does not add structure to properties.
 
 Forms are not special in the information model, but are merely statements around a blank node.
 They can be special in serialization formats (which have more efficient notations for them),

--- a/draft-ietf-core-coral.md
+++ b/draft-ietf-core-coral.md
@@ -314,7 +314,7 @@ Note that the "temperature-c" interface and "sensor" resource type get code poin
 
 #### Literal example {#literalexample}
 
-To illustrate properties of literals, a link example of {{RFC8288}} is converted.
+To illustrate non-trivial literals, a link example of {{RFC8288}} is converted.
 
 (Note that even the conversion scheme hinted at above for {{RFC6690}} link format makes no claims at being applicable to general purpose web links like the below;
 this is merely done to demonstrate how literals can be handled.
@@ -333,7 +333,7 @@ The model this would be converted to is:
 | Subject | Predicate | Object |
 |---------+-----------+--------+
 | http://.../ | rel:previous | http://.../TheBook/chapter2 |
-| http://.../TheBook/chapter2 | linkformat:title | "letztes Kapitel" with xml:lang "de" |
+| http://.../TheBook/chapter2 | linkformat:title | "letztes Kapitel" in language "de" |
 {: #fig-8288-data-properties title='Information model extracted from above'}
 
 In CBOR serialization, this produces:
@@ -341,9 +341,7 @@ In CBOR serialization, this produces:
 ~~~
 [
   [2, 6(...) / rel:previous /, cri"/TheBook/chapter2", [
-    [2, simple(15) / item 15 for linkformat:title /, "letztes Kapitel", [
-      [2, 6(...) / xml:lang /, "de"]
-    ]]
+    [2, simple(15) / item 15 for linkformat:title /, 38(["de", "letztes Kapitel"])]
   ]]
 ]
 ~~~

--- a/draft-ietf-core-coral.md
+++ b/draft-ietf-core-coral.md
@@ -306,7 +306,7 @@ the use of the packing described with the conversion results in a binary CBOR fi
   ]]
 ]
 ~~~
-{: #fig-6690-serialzied title='Serialized CoRAL file in diagnostic notation.'}
+{: #fig-6690-serialized title='Serialized CoRAL file in diagnostic notation.'}
 
 \[ TBD: Numbers are made up \]
 
@@ -333,8 +333,8 @@ The model this would be converted to is:
 | Subject | Predicate | Object |
 |---------+-----------+--------+
 | http://.../ | rel:previous | http://.../TheBook/chapter2 |
-| http://.../TheBook/chapter2 | linkformat:title | "letztes Kapitel" in language "de" |
-{: #fig-8288-data-properties title='Information model extracted from above'}
+| http://.../TheBook/chapter2 | linkformat:title | "letztes Kapitel" with language tag "de" |
+{: #fig-8288-tagged-literals title='Information model extracted from above'}
 
 In CBOR serialization, this produces:
 
@@ -345,7 +345,7 @@ In CBOR serialization, this produces:
   ]]
 ]
 ~~~
-{: #fig-8288-serialzied title='Serialization of the RFC8288-based example'}
+{: #fig-8288-serialized title='Serialization of the RFC8288-based example'}
 
 ### Interaction model
 
@@ -1238,10 +1238,7 @@ For example, a CoRAL document could use the [FOAF vocabulary](#FOAF) to describe
 ## Expressing Natural Language Texts
 
 Text strings can be associated with a [Language Tag](#RFC5646) and a base text direction
-(right-to-left or left-to-right) by nesting links of types
-\<http://coreapps.org/base#language> and
-\<http://coreapps.org/base#direction>,
-respectively:
+(right-to-left or left-to-right) by using CBOR tag 38.
 
 <ul empty="true"><li markdown="1">
 ~~~~ coral
@@ -1249,8 +1246,9 @@ respectively:
 ~~~~
 </li></ul>
 
-The link relation types \<http://coreapps.org/base#language> and
-\<http://coreapps.org/base#direction> are defined in {{core-vocabulary}}.
+\[ Maturity note: Whether direction will actually be expressed in an updated tag 38,
+   how precisely that is done, or whether a new tag will be allocated for text with direction
+   is currently still under discussion. \]
 
 
 ## Embedding Representations in CoRAL
@@ -1468,25 +1466,9 @@ Link Relation Types:
 : Indicates that the link target is a human-readable label (e.g., a
   menu entry).
 
-  The link target MUST be a text string. The text string SHOULD be
-  annotated with a language and text direction using nested links of
-  type \<http://coreapps.org/base#language> and
-  \<http://coreapps.org/base#direction>, respectively.
-
-\<http://coreapps.org/base#language>
-: Indicates that the link target is a [Language Tag](#RFC5646) that
-  specifies the language of the link context.
-
-  The link target MUST be a text string in the format specified in
-  {{Section 2.1 of RFC5646}}.
-
-\<http://coreapps.org/base#direction>
-: Indicates that the link target is a base text direction
-  (right-to-left or left-to-right) that specifies the text
-  directionality of the link context.
-
-  The link target MUST be either the text string "rtl" or the text
-  string "ltr".
+  The link target MUST be a literal. The text string SHOULD be
+  wrapped in a tag indicating language and, if necessary, direction
+  if applicable.
 
 \<http://coreapps.org/base#representation>
 : Indicates that the link target is a representation of the link
@@ -1660,11 +1642,7 @@ This section defines a default dictionary that is assumed when the `application/
 |   6 | &lt;http://coreapps.org/base#search&gt;                     |
 |   7 | &lt;http://coreapps.org/coap#accept&gt;                     |
 |   8 | &lt;http://coreapps.org/coap#type&gt;                       |
-|   9 | &lt;http://coreapps.org/base#language&gt;                   |
 |  10 | &lt;http://coreapps.org/coap#method&gt;                     |
-|  11 | &lt;http://coreapps.org/base#direction&gt;                  |
-|  12 | "ltr"                                                       |
-|  13 | "rtl"                                                       |
 |  14 | &lt;http://coreapps.org/base#representation&gt;             |
 {: #default-dictionary-entries align="center" cols="r l"
 title="Default Dictionary" }
@@ -1696,9 +1674,8 @@ as long as some basic restrictions are met:
 * A blank node of CoRAL can only have one incoming edge in serialization.
   RDF documents with multiply connected blank nodes need to undergo skolemization before they can be expressed in CoRAL.
 
-* CoRAL supports arbitrary literal objects, including CBOR tags, and arbitrary properties.
+* CoRAL supports arbitrary literal objects, including CBOR tags.
   For each object that is used in a literal, a mapping to a datatype (typically XSD) needs to be defined.
-  Properties of CoRAL literals need to be limited to those properties expressible in RDF (datatype, language and/or internationalization).
 
   When literals are normalized in RDF according to XSD rules,
   or the literal mappings to RDF datatypes are ambiguous on the CoRAL side,
@@ -1714,14 +1691,7 @@ Any blank node of RDF is converted to a blank node (serialized as a null) in CoR
 (Beware that depending on the context established in {{docsemantics}}, the retrieval context may be a URI or a blank node).
 Literals are converted as follows:
 
-* CBOR text strings are coverted to RDF strig literals.
-
-  If they have a CRI-valued rdf:datatype property, the corresponding URI is set as the RDF literal's datatype.
-
-  If they have a string-valued xml:lang property, the corresponding URI is set as the RDF literal's language;
-  this is requires the datatype to be rdf:langString or absent.
-
-  If any other properties are present, the conversion fails.
+* CBOR text strings are coverted to RDF string literals without a language tag.
 
 * CBOR literals from the following list are converted to their corresponding text representations of the datatype from the following table:
 
@@ -1733,12 +1703,12 @@ Literals are converted as follows:
 | decfrac | xsd:decimal |
 | bytes | xsd:base64Binary or xsd:base64hexBinary (?) |
 | tdate | xsd:date |
+| #6.38([lang: tstr, text: tstr]) | rdf:langString with lang as language tag |
+| #6.TBD([lang: tstr, dir: tstr, text: tstr]) | i18n:{lang}_{dir} |
 {: #cddl-xsd-mappings title="Mapping between CDDL types and XSD datatypes" }
 
-  If a CBOR literal has a concrete rdf:datatype attached,
-  and \[ there is probably some XSD subtyping term we can use here \], that type is set as the datatype instead.
-
-\[ TBD: Check compatibilities, give type for at least the basic tags \]
+\[ TBD: Check compatibilities, give type for at least the basic tags.
+   Directional text might wind up in tag 38, \]
 
 * RDF literals are mapped to any CoRAL literal that yields an equivalent RDF literal in the opposite direction.
 
@@ -1846,7 +1816,7 @@ Available mechanisms are:
   The attribute value is stored as a text string literal.
   If the Link Format attribute is language tagged
   (i.e. when the attribute name ends with an asterisk and the value is of ext-value shape),
-  the literal gets the language set as an xml:lang property.
+  the literal is encapsulated in a CBOR language tag (38).
 * int:
   The target attribute is processed as an ASCII encoded number
   and expressed as an integer literal.

--- a/textual/examples/natural-language-texts.coral
+++ b/textual/examples/natural-language-texts.coral
@@ -2,12 +2,7 @@
 #using iana = <http://www.iana.org/assignments/relation/>
 
 iana:terms-of-service </tos> {
-   base:title "Nutzungsbedingungen" {
-      @language  "de"
-      @direction "ltr"
-   }
-   base:title "Terms of use" {
-      @language  "en-US"
-      @direction "ltr"
-   }
+   base:title 38(["de", "Nutzungsbedingungen"])
+   base:title 38(["en-US", "Terms of use"])
+   base:title 38(["az", "ltr", "İstifadə şərtləri"])
 }


### PR DESCRIPTION
With direction on its way into a tag (discussion pending -- will it be a dedicated one or inside 38), the only use case we had for properties on literals is gone.

I think the whole model is better if we remove them -- anything that can be expressed with properties can also be expressed with tags, but the latter are well defined and understood whereas the former are not. (What does it mean if two properties are on a literal and both are defined but their interaction is not? Tags are clearer there).

PR is incomplete, needs a few more alterations.