### PR TITLE
Data interaction model merging

### DIFF
--- a/draft-ietf-core-coral.md
+++ b/draft-ietf-core-coral.md
@@ -152,7 +152,61 @@ as a compact serialization format.
 
 ## Data and Interaction Model
 
-### Definitions
+The data model is similar to the [Resource Description Framework (RDF)](#W3C.REC-rdf11-concepts-20140225) model,
+with provisions to enable form based interaction
+and to express data from Web Linking ({{RFC8288}}) based models such as {{RFC6690}}'s Link Format.
+
+The interaction model derives from the processing model of [HTML](#W3C.REC-html52-20171214) and specifies how an
+automated software agent can change the application state by
+navigating between resources following links and performing operations
+on resources submitting forms.
+
+## Notational Conventions
+
+{::boilerplate bcp14-tagged}
+
+Terms defined in this document appear in *cursive* where they
+are introduced (rendered in plain text as the new term surrounded by
+underscores).
+
+
+# Data and Interaction Model {#model}
+
+The Constrained RESTful Application Language (CoRAL) is designed for
+building [Web-based applications](#W3C.REC-webarch-20041215) in which
+automated software agents navigate between resources by following
+links and perform operations on resources by submitting forms.
+
+
+## Browsing Context
+
+Borrowing from [HTML 5](#W3C.REC-html52-20171214),
+each such agent maintains a *browsing context* in which the
+representations of Web resources are processed.
+(In HTML, the browsing context typically corresponds to a tab or
+window in a Web browser.)
+
+At any time, one representation in a browsing context is designated
+the *active* representation.
+
+
+## Documents
+
+A resource representation in one of the CoRAL serialization formats is
+called a CoRAL *document*.
+The URI that was used to retrieve such a document is called the
+document's *retrieval context*.
+This URI is also considered the base URI for relative URI references
+in the document.
+
+A CoRAL document consists of a list of zero or more statements
+that can express links or (in a composition of statements) forms.
+CoRAL serialization formats may contain additional elements
+for efficiency or convenience, such as an embedded base URI that takes
+precedence over the document's base URI,
+or to concisely represent compound statements (e.g., to express forms).
+
+## Data model
 
 The *basic CoRAL information model* is similar to the [Resource Description Framework (RDF)](#W3C.REC-rdf11-concepts-20140225) information model:
 Data is expressed as an (unordered) set of triples (also called statements),
@@ -347,14 +401,6 @@ In CBOR serialization, this produces:
 ~~~
 {: #fig-8288-serialized title='Serialization of the RFC8288-based example'}
 
-### Interaction model
-
-The interaction model derives from the processing model of [HTML](#W3C.REC-html52-20171214) and specifies how an
-automated software agent can change the application state by
-navigating between resources following links and performing operations
-on resources submitting forms.
-
-
 ## Serialization Format
 
 The primary serialization format is a compact, binary encoding of
@@ -382,50 +428,6 @@ the RDF [Turtle](#W3C.REC-turtle-20140225) format
 can be used when only the basic information model content is to be conveyed.
 When used like this, the conversion according to the RDF appendix is implied.
 \]
-
-## Notational Conventions
-
-{::boilerplate bcp14-tagged}
-
-Terms defined in this document appear in *cursive* where they
-are introduced (rendered in plain text as the new term surrounded by
-underscores).
-
-
-# Data and Interaction Model {#model}
-
-The Constrained RESTful Application Language (CoRAL) is designed for
-building [Web-based applications](#W3C.REC-webarch-20041215) in which
-automated software agents navigate between resources by following
-links and perform operations on resources by submitting forms.
-
-
-## Browsing Context
-
-Borrowing from [HTML 5](#W3C.REC-html52-20171214),
-each such agent maintains a *browsing context* in which the
-representations of Web resources are processed.
-(In HTML, the browsing context typically corresponds to a tab or
-window in a Web browser.)
-
-At any time, one representation in a browsing context is designated
-the *active* representation.
-
-
-## Documents
-
-A resource representation in one of the CoRAL serialization formats is
-called a CoRAL *document*.
-The URI that was used to retrieve such a document is called the
-document's *retrieval context*.
-This URI is also considered the base URI for relative URI references
-in the document.
-
-A CoRAL document consists of a list of zero or more links and forms,
-collectively called *elements*.
-CoRAL serialization formats may define additional types of elements
-for efficiency or convenience, such as an embedded base URI that takes
-precedence over the document's base URI.
 
 
 ## Links

--- a/draft-ietf-core-coral.md
+++ b/draft-ietf-core-coral.md
@@ -432,14 +432,14 @@ When used like this, the conversion according to the RDF appendix is implied.
 
 ## Links
 
-\[ TBD move information model in here \]
+Any statement "links" a resource with a second resource or literal,
+and is thus also referred to as a link.
 
-A *link* describes a relationship between two resources on the
-Web.
-As in {{RFC8288}}, a link in CoRAL has
-a *link context*,
-a *link relation type*, and
-a *link target*.
+In {{RFC8288}} terminology, a CoRAL link's
+subject is the *link context*,
+the predicate is the *link relation type*, and
+the object is the *link target*.
+
 However, a link in CoRAL does not have target attributes. Instead, a
 link may have a list of zero or more nested elements. These enable
 both the description of resource metadata and the chaining of links,
@@ -466,23 +466,16 @@ In CoRAL documents, these URIs are only used as identity tokens,
 though, and are compared with Simple String Comparison as specified in
 {{Section 6.2.1 of RFC3986}}.
 
-Link contexts and link targets can both be either a URI, a literal
-value, or an anonymous resource.
 If the link target is a URI and the URI scheme indicates a Web
 transfer protocol like HTTP or CoAP, an agent can dereference the URI
 and navigate the browsing context to its target resource; this is
 called *following the link*.
-Literal values are distinct and distinguishable from URIs and directly
-identify data by means of a literal representation.
-A literal value can be either
-a Boolean value,
-an integer number,
-a floating-point number,
-a date/time instant,
-a byte string, or
-a text string.
 An anonymous resource is a resource that is identified by neither a
 URI nor a literal representation.
+The agent can still follow the link,
+but can not dereference it
+and is limited in its next steps by the outgoing links
+that are expressed in the current document.
 
 A link can occur as a top-level element in a document or as a nested
 element within a link. When a link occurs as a top-level element, the
@@ -509,6 +502,12 @@ a *request method*, and
 a *submission target*.
 Additionally, a form may be accompanied by a list of zero or more
 *form fields*.
+
+In the basic information model,
+the form is identified with an anonymous node.
+The form context and operation type are the subject and predicate of an incoming link, respectively;
+request method and submission target of an outgoing link.
+Form fields are additional links from that form.
 
 > A form can be viewed as an instruction of the form "To perform an
   {operation type} operation on {form context}, make a {request
@@ -554,19 +553,8 @@ Additionally, a form field may have a list of zero or more nested
 elements that further describe the form field value.
 
 A form field type identifies the semantics of the form field.
-Form field types are denoted (like link relation types and operation
-types) by a URI.
-
-Form field values can be either
-a URI,
-a Boolean value,
-an integer number,
-a floating-point number,
-a date/time instant,
-a byte string,
-a text string, or
-null.
-A null indicates the intentional absence of any form field value.
+Form field types are predicates and thus URIs.
+Form field values are URIs, blank nodes or literals.
 
 
 ## Navigation
@@ -699,7 +687,7 @@ The media type of documents in the binary format is `application/coral+cbor`.
 The data structure of a document in the binary format is made up of
 three kinds of elements:
 links,
-forms, and
+forms (as short hands for the statements they are constructed of), and
 (as an extension to the CoRAL data model) directives.
 Directives provide a way to encode URI references with a common base
 more efficiently.


### PR DESCRIPTION
The introduction of the graph/statement based data model caused duplication between sections and text.

This moves things into a common structure and removes textual duplication, smoothing some (but not all) of the rough edges.